### PR TITLE
declare additional app dependencies

### DIFF
--- a/template/staging.tmpl
+++ b/template/staging.tmpl
@@ -160,7 +160,8 @@
     "Type": "AWS::Kinesis::Stream",
     "Properties": {
       "ShardCount": 1
-    }
+    },
+    "DependsOn": ["ServiceRole"]
   },
   {{ if .HasProcesses }}
     "LogsUser": {
@@ -270,7 +271,8 @@
       "GroupDescription": { "Fn::Join": [ " ", [ { "Ref": "AWS::StackName" }, "-balancer" ] ] },
       "SecurityGroupIngress": [ {{ ingress . }} ],
       "VpcId": { "Ref": "VPC" }
-    }
+    },
+    "DependsOn": ["ServiceRole"]
   },
   "Balancer": {
     "Type": "AWS::ElasticLoadBalancing::LoadBalancer",


### PR DESCRIPTION
Apps are not getting deleted with the current app formation stack:

![screen shot 2015-09-01 at 4 53 27 pm](https://cloud.githubusercontent.com/assets/173457/9619940/fdc0857e-50c9-11e5-9611-29fbea089c40.png)

Seems like adding the ServiceRole to `DependsOn` for these two services could take care of it.
