### PR TITLE
Don't include ELB in the stack if there are no ports defined.

### DIFF
--- a/fixtures/worker.json
+++ b/fixtures/worker.json
@@ -1,0 +1,582 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": {
+    "BlankCluster": {
+      "Fn::Equals": [
+        {
+          "Ref": "Cluster"
+        },
+        ""
+      ]
+    },
+    "BlankPostgresService": {
+      "Fn::Equals": [
+        {
+          "Ref": "PostgresService"
+        },
+        ""
+      ]
+    },
+    "BlankWorkerService": {
+      "Fn::Equals": [
+        {
+          "Ref": "WorkerService"
+        },
+        ""
+      ]
+    }
+  },
+  "Outputs": {
+    "Kinesis": {
+      "Value": {
+        "Ref": "Kinesis"
+      }
+    },
+    "Settings": {
+      "Value": {
+        "Ref": "Settings"
+      }
+    }
+  },
+  "Parameters": {
+    "Cluster": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "Cpu": {
+      "Default": "200",
+      "Description": "CPU shares of each process",
+      "Type": "Number"
+    },
+    "Environment": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "Key": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "PostgresCommand": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "PostgresDesiredCount": {
+      "Default": "1",
+      "Description": "The number of instantiations of the process to place and keep running on your cluster",
+      "Type": "Number"
+    },
+    "PostgresImage": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "PostgresMemory": {
+      "Default": "256",
+      "Description": "MB of RAM to reserve",
+      "Type": "Number"
+    },
+    "PostgresService": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "Release": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "Repository": {
+      "Default": "",
+      "Description": "Source code repository",
+      "Type": "String"
+    },
+    "Subnets": {
+      "Default": "",
+      "Description": "VPC subnets for this app",
+      "Type": "List\u003cAWS::EC2::Subnet::Id\u003e"
+    },
+    "VPC": {
+      "Default": "",
+      "Description": "VPC for this app",
+      "Type": "AWS::EC2::VPC::Id"
+    },
+    "Version": {
+      "Default": "latest",
+      "Description": "Convox release version",
+      "Type": "String"
+    },
+    "WorkerCommand": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "WorkerDesiredCount": {
+      "Default": "1",
+      "Description": "The number of instantiations of the process to place and keep running on your cluster",
+      "Type": "Number"
+    },
+    "WorkerImage": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "WorkerMemory": {
+      "Default": "256",
+      "Description": "MB of RAM to reserve",
+      "Type": "Number"
+    },
+    "WorkerService": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "CustomTopic": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Join": [
+              "-",
+              [
+                "convox",
+                {
+                  "Ref": "AWS::Region"
+                }
+              ]
+            ]
+          },
+          "S3Key": {
+            "Fn::Join": [
+              "",
+              [
+                "release/",
+                {
+                  "Ref": "Version"
+                },
+                "/formation.zip"
+              ]
+            ]
+          }
+        },
+        "Handler": "lambda.external",
+        "MemorySize": "128",
+        "Role": {
+          "Fn::GetAtt": [
+            "CustomTopicRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs",
+        "Timeout": "30"
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "CustomTopicRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Effect": "Allow",
+                  "Resource": "*"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "Administrator"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "Kinesis": {
+      "Properties": {
+        "ShardCount": 1
+      },
+      "Type": "AWS::Kinesis::Stream"
+    },
+    "LogsAccess": {
+      "Properties": {
+        "Serial": "1",
+        "Status": "Active",
+        "UserName": {
+          "Ref": "LogsUser"
+        }
+      },
+      "Type": "AWS::IAM::AccessKey"
+    },
+    "LogsUser": {
+      "Properties": {
+        "Path": "/convox/",
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "kinesis:PutRecords"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:kinesis:*:*:stream/",
+                          {
+                            "Ref": "AWS::StackName"
+                          },
+                          "-*"
+                        ]
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "LogsRole"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::User"
+    },
+    "PostgresECSService": {
+      "DependsOn": "CustomTopic",
+      "Properties": {
+        "Cluster": {
+          "Ref": "Cluster"
+        },
+        "DesiredCount": {
+          "Ref": "PostgresDesiredCount"
+        },
+        "LoadBalancers": [],
+        "Name": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName"
+              },
+              "postgres"
+            ]
+          ]
+        },
+        "Role": {
+          "Ref": "ServiceRole"
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomTopic",
+            "Arn"
+          ]
+        },
+        "TaskDefinition": {
+          "Ref": "PostgresECSTaskDefinition"
+        }
+      },
+      "Type": "Custom::ECSService",
+      "Version": "1.0"
+    },
+    "PostgresECSTaskDefinition": {
+      "DependsOn": [
+        "CustomTopic",
+        "ServiceRole"
+      ],
+      "Properties": {
+        "Environment": {
+          "Ref": "Environment"
+        },
+        "Key": {
+          "Ref": "Key"
+        },
+        "Name": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName"
+              },
+              "postgres"
+            ]
+          ]
+        },
+        "Release": {
+          "Ref": "Release"
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomTopic",
+            "Arn"
+          ]
+        },
+        "Tasks": [
+          {
+            "Fn::If": [
+              "BlankPostgresService",
+              {
+                "CPU": {
+                  "Ref": "Cpu"
+                },
+                "Command": {
+                  "Ref": "PostgresCommand"
+                },
+                "Environment": {
+                  "KINESIS": {
+                    "Ref": "Kinesis"
+                  },
+                  "POSTGRES_PASSWORD": "password",
+                  "POSTGRES_USERNAME": "postgres",
+                  "PROCESS": "postgres"
+                },
+                "Image": {
+                  "Ref": "PostgresImage"
+                },
+                "Links": [],
+                "Memory": {
+                  "Ref": "PostgresMemory"
+                },
+                "Name": "postgres",
+                "PortMappings": [],
+                "Services": [],
+                "Volumes": []
+              },
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ]
+          }
+        ]
+      },
+      "Type": "Custom::ECSTaskDefinition",
+      "Version": "1.0"
+    },
+    "ServiceRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "ecs.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "elasticloadbalancing:Describe*",
+                    "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                    "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+                    "ec2:Describe*",
+                    "ec2:AuthorizeSecurityGroupIngress"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    "*"
+                  ]
+                }
+              ]
+            },
+            "PolicyName": "ServiceRole"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "Settings": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AccessControl": "Private",
+        "Tags": [
+          {
+            "Key": "system",
+            "Value": "convox"
+          },
+          {
+            "Key": "app",
+            "Value": {
+              "Ref": "AWS::StackName"
+            }
+          }
+        ]
+      },
+      "Type": "AWS::S3::Bucket"
+    },
+    "WorkerECSService": {
+      "DependsOn": "CustomTopic",
+      "Properties": {
+        "Cluster": {
+          "Ref": "Cluster"
+        },
+        "DesiredCount": {
+          "Ref": "WorkerDesiredCount"
+        },
+        "LoadBalancers": [],
+        "Name": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName"
+              },
+              "worker"
+            ]
+          ]
+        },
+        "Role": {
+          "Ref": "ServiceRole"
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomTopic",
+            "Arn"
+          ]
+        },
+        "TaskDefinition": {
+          "Ref": "WorkerECSTaskDefinition"
+        }
+      },
+      "Type": "Custom::ECSService",
+      "Version": "1.0"
+    },
+    "WorkerECSTaskDefinition": {
+      "DependsOn": [
+        "CustomTopic",
+        "ServiceRole"
+      ],
+      "Properties": {
+        "Environment": {
+          "Ref": "Environment"
+        },
+        "Key": {
+          "Ref": "Key"
+        },
+        "Name": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName"
+              },
+              "worker"
+            ]
+          ]
+        },
+        "Release": {
+          "Ref": "Release"
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomTopic",
+            "Arn"
+          ]
+        },
+        "Tasks": [
+          {
+            "Fn::If": [
+              "BlankWorkerService",
+              {
+                "CPU": {
+                  "Ref": "Cpu"
+                },
+                "Command": {
+                  "Ref": "WorkerCommand"
+                },
+                "Environment": {
+                  "KINESIS": {
+                    "Ref": "Kinesis"
+                  },
+                  "PROCESS": "worker"
+                },
+                "Image": {
+                  "Ref": "WorkerImage"
+                },
+                "Links": [
+                  {
+                    "Fn::If": [
+                      "BlankPostgresService",
+                      {
+                        "Ref": "AWS::NoValue"
+                      },
+                      {
+                        "Ref": "AWS::NoValue"
+                      }
+                    ]
+                  }
+                ],
+                "Memory": {
+                  "Ref": "WorkerMemory"
+                },
+                "Name": "worker",
+                "PortMappings": [],
+                "Services": [
+                  {
+                    "Fn::If": [
+                      "BlankPostgresService",
+                      {
+                        "Ref": "AWS::NoValue"
+                      },
+                      {
+                        "Fn::Join": [
+                          ":",
+                          [
+                            {
+                              "Ref": "PostgresService"
+                            },
+                            "postgres"
+                          ]
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "Volumes": []
+              },
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ]
+          }
+        ]
+      },
+      "Type": "Custom::ECSTaskDefinition",
+      "Version": "1.0"
+    }
+  }
+}

--- a/fixtures/worker.yml
+++ b/fixtures/worker.yml
@@ -1,0 +1,14 @@
+worker:
+  build: .
+  environment:
+   - AWS_ACCESS_KEY
+   - AWS_SECRET_ACCESS_KEY
+  links:
+    - postgres
+  volumes:
+    - .:/app
+postgres:
+  image: mdillon/postgis
+  environment:
+   - POSTGRES_USERNAME=postgres
+   - POSTGRES_PASSWORD=password

--- a/main.go
+++ b/main.go
@@ -484,6 +484,10 @@ func (m Manifest) FirstRandom() string {
 }
 
 func (m Manifest) HasPorts() bool {
+	if len(m) == 0 {
+		return true // special case to pre-initialize ELB at app create
+	}
+
 	for _, me := range m {
 		if len(me.Ports) > 0 {
 			return true

--- a/main_test.go
+++ b/main_test.go
@@ -41,6 +41,19 @@ func TestStagingWebPostgis(t *testing.T) {
 	_assert(t, cases)
 }
 
+func TestStagingWorker(t *testing.T) {
+	manifest := readManifest(t, "fixtures", "worker.yml")
+	template := readFile(t, "fixtures", "worker.json")
+
+	data, _ := buildTemplate("staging", "formation", func() string { return "12345" }, manifest)
+
+	cases := Cases{
+		{strings.TrimSpace(data), strings.TrimSpace(string(template))},
+	}
+
+	_assert(t, cases)
+}
+
 func readFile(t *testing.T, dir string, name string) []byte {
 	filename := filepath.Join(dir, name)
 

--- a/template/staging.tmpl
+++ b/template/staging.tmpl
@@ -249,53 +249,53 @@
 
 {{ define "balancer-outputs" }}
   {{ if .HasPorts }}
-	  "BalancerHost": {
-	    "Value": { "Fn::GetAtt": [ "Balancer", "DNSName" ] }
-	  },
-	  {{ range $ps, $entry := . }}
-	    {{ if $entry.HasPorts }}
-	      {{ range $entry.Ports }}
-	        {{ $parts := (split . ":") }}
-	        "{{ upper $ps }}Port{{ index $parts 0 }}Balancer": {
-	          "Value": { "Ref": "{{ upper $ps }}Port{{ index $parts 0 }}Balancer" }
-	        },
-	      {{ end }}
-	    {{ end }}
-	  {{ end }}
+    "BalancerHost": {
+      "Value": { "Fn::GetAtt": [ "Balancer", "DNSName" ] }
+    },
+    {{ range $ps, $entry := . }}
+      {{ if $entry.HasPorts }}
+        {{ range $entry.Ports }}
+          {{ $parts := (split . ":") }}
+          "{{ upper $ps }}Port{{ index $parts 0 }}Balancer": {
+            "Value": { "Ref": "{{ upper $ps }}Port{{ index $parts 0 }}Balancer" }
+          },
+        {{ end }}
+      {{ end }}
+    {{ end }}
   {{ end }}
 {{ end }}
 
 {{ define "balancer-resources" }}
   {{ if .HasPorts }}
-	  "BalancerSecurityGroup": {
-	    "Type": "AWS::EC2::SecurityGroup",
-	    "Properties": {
-	      "GroupDescription": { "Fn::Join": [ " ", [ { "Ref": "AWS::StackName" }, "-balancer" ] ] },
-	      "SecurityGroupIngress": [ {{ ingress . }} ],
-	      "VpcId": { "Ref": "VPC" }
-	    }
-	  },
-	  "Balancer": {
-	    "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
-	    "Properties": {
-	      "Subnets": { "Ref": "Subnets" },
-	      "ConnectionDrainingPolicy": { "Enabled": true, "Timeout": 60 },
-	      "ConnectionSettings": { "IdleTimeout": 60 },
-	      "CrossZone": true,
-	      "HealthCheck": {
-	        "HealthyThreshold": "2",
-	        "Interval": 5,
-	        "Target": {{ .FirstCheck }},
-	        "Timeout": 3,
-	        "UnhealthyThreshold": "2"
-	      },
-	      "Listeners": [ {{ listeners . }} ],
-	      "LBCookieStickinessPolicy": [{ "PolicyName": "affinity" }],
-	      "LoadBalancerName": { "Ref": "AWS::StackName" },
-	      "SecurityGroups": [ { "Ref": "BalancerSecurityGroup" } ]
-	    }
-	  },
-	{{ end }}
+    "BalancerSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": { "Fn::Join": [ " ", [ { "Ref": "AWS::StackName" }, "-balancer" ] ] },
+        "SecurityGroupIngress": [ {{ ingress . }} ],
+        "VpcId": { "Ref": "VPC" }
+      }
+    },
+    "Balancer": {
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+      "Properties": {
+        "Subnets": { "Ref": "Subnets" },
+        "ConnectionDrainingPolicy": { "Enabled": true, "Timeout": 60 },
+        "ConnectionSettings": { "IdleTimeout": 60 },
+        "CrossZone": true,
+        "HealthCheck": {
+          "HealthyThreshold": "2",
+          "Interval": 5,
+          "Target": {{ .FirstCheck }},
+          "Timeout": 3,
+          "UnhealthyThreshold": "2"
+        },
+        "Listeners": [ {{ listeners . }} ],
+        "LBCookieStickinessPolicy": [{ "PolicyName": "affinity" }],
+        "LoadBalancerName": { "Ref": "AWS::StackName" },
+        "SecurityGroups": [ { "Ref": "BalancerSecurityGroup" } ]
+      }
+    },
+  {{ end }}
 {{ end }}
 
 {{ define "security" }}

--- a/template/staging.tmpl
+++ b/template/staging.tmpl
@@ -248,50 +248,54 @@
 {{ end }}
 
 {{ define "balancer-outputs" }}
-  "BalancerHost": {
-    "Value": { "Fn::GetAtt": [ "Balancer", "DNSName" ] }
-  },
-  {{ range $ps, $entry := . }}
-    {{ if $entry.HasPorts }}
-      {{ range $entry.Ports }}
-        {{ $parts := (split . ":") }}
-        "{{ upper $ps }}Port{{ index $parts 0 }}Balancer": {
-          "Value": { "Ref": "{{ upper $ps }}Port{{ index $parts 0 }}Balancer" }
-        },
-      {{ end }}
-    {{ end }}
+  {{ if .HasPorts }}
+	  "BalancerHost": {
+	    "Value": { "Fn::GetAtt": [ "Balancer", "DNSName" ] }
+	  },
+	  {{ range $ps, $entry := . }}
+	    {{ if $entry.HasPorts }}
+	      {{ range $entry.Ports }}
+	        {{ $parts := (split . ":") }}
+	        "{{ upper $ps }}Port{{ index $parts 0 }}Balancer": {
+	          "Value": { "Ref": "{{ upper $ps }}Port{{ index $parts 0 }}Balancer" }
+	        },
+	      {{ end }}
+	    {{ end }}
+	  {{ end }}
   {{ end }}
 {{ end }}
 
 {{ define "balancer-resources" }}
-  "BalancerSecurityGroup": {
-    "Type": "AWS::EC2::SecurityGroup",
-    "Properties": {
-      "GroupDescription": { "Fn::Join": [ " ", [ { "Ref": "AWS::StackName" }, "-balancer" ] ] },
-      "SecurityGroupIngress": [ {{ ingress . }} ],
-      "VpcId": { "Ref": "VPC" }
-    }
-  },
-  "Balancer": {
-    "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
-    "Properties": {
-      "Subnets": { "Ref": "Subnets" },
-      "ConnectionDrainingPolicy": { "Enabled": true, "Timeout": 60 },
-      "ConnectionSettings": { "IdleTimeout": 60 },
-      "CrossZone": true,
-      "HealthCheck": {
-        "HealthyThreshold": "2",
-        "Interval": 5,
-        "Target": {{ .FirstCheck }},
-        "Timeout": 3,
-        "UnhealthyThreshold": "2"
-      },
-      "Listeners": [ {{ listeners . }} ],
-      "LBCookieStickinessPolicy": [{ "PolicyName": "affinity" }],
-      "LoadBalancerName": { "Ref": "AWS::StackName" },
-      "SecurityGroups": [ { "Ref": "BalancerSecurityGroup" } ]
-    }
-  },
+  {{ if .HasPorts }}
+	  "BalancerSecurityGroup": {
+	    "Type": "AWS::EC2::SecurityGroup",
+	    "Properties": {
+	      "GroupDescription": { "Fn::Join": [ " ", [ { "Ref": "AWS::StackName" }, "-balancer" ] ] },
+	      "SecurityGroupIngress": [ {{ ingress . }} ],
+	      "VpcId": { "Ref": "VPC" }
+	    }
+	  },
+	  "Balancer": {
+	    "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+	    "Properties": {
+	      "Subnets": { "Ref": "Subnets" },
+	      "ConnectionDrainingPolicy": { "Enabled": true, "Timeout": 60 },
+	      "ConnectionSettings": { "IdleTimeout": 60 },
+	      "CrossZone": true,
+	      "HealthCheck": {
+	        "HealthyThreshold": "2",
+	        "Interval": 5,
+	        "Target": {{ .FirstCheck }},
+	        "Timeout": 3,
+	        "UnhealthyThreshold": "2"
+	      },
+	      "Listeners": [ {{ listeners . }} ],
+	      "LBCookieStickinessPolicy": [{ "PolicyName": "affinity" }],
+	      "LoadBalancerName": { "Ref": "AWS::StackName" },
+	      "SecurityGroups": [ { "Ref": "BalancerSecurityGroup" } ]
+	    }
+	  },
+	{{ end }}
 {{ end }}
 
 {{ define "security" }}


### PR DESCRIPTION
Addresses convox/app#17.

This will exclude balancer resources from the stack if the manifest is not empty and there are no ports. The "manifest is not empty" part is there so that we pre-initialize ELB at app create time since that can take a while. When the first push comes in with no ports configured, the stack should be updated to remove the balancer and the associated resources cleaned up.