### PR TITLE
Map ports w/o ELB

### DIFF
--- a/fixtures/web_postgis.json
+++ b/fixtures/web_postgis.json
@@ -1,3 +1,4 @@
+len:  2
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Conditions": {
@@ -144,12 +145,17 @@
     },
     "WebPort5000Balancer": {
       "Default": "5000",
-      "Description": "",
+      "Description": "Externally bound port number",
+      "Type": "String"
+    },
+    "WebPort5000Container": {
+      "Default": "3000",
+      "Description": "Exposed port from within container",
       "Type": "String"
     },
     "WebPort5000Host": {
       "Default": "12345",
-      "Description": "",
+      "Description": "Container host mapped port",
       "Type": "String"
     },
     "WebService": {

--- a/fixtures/web_postgis.json
+++ b/fixtures/web_postgis.json
@@ -1,4 +1,3 @@
-len:  2
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Conditions": {

--- a/fixtures/web_postgis_internal.json
+++ b/fixtures/web_postgis_internal.json
@@ -1,0 +1,600 @@
+len:  1
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": {
+    "BlankCluster": {
+      "Fn::Equals": [
+        {
+          "Ref": "Cluster"
+        },
+        ""
+      ]
+    },
+    "BlankPostgresService": {
+      "Fn::Equals": [
+        {
+          "Ref": "PostgresService"
+        },
+        ""
+      ]
+    },
+    "BlankWebService": {
+      "Fn::Equals": [
+        {
+          "Ref": "WebService"
+        },
+        ""
+      ]
+    }
+  },
+  "Outputs": {
+    "Kinesis": {
+      "Value": {
+        "Ref": "Kinesis"
+      }
+    },
+    "Settings": {
+      "Value": {
+        "Ref": "Settings"
+      }
+    }
+  },
+  "Parameters": {
+    "Cluster": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "Cpu": {
+      "Default": "200",
+      "Description": "CPU shares of each process",
+      "Type": "Number"
+    },
+    "Environment": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "Key": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "PostgresCommand": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "PostgresDesiredCount": {
+      "Default": "1",
+      "Description": "The number of instantiations of the process to place and keep running on your cluster",
+      "Type": "Number"
+    },
+    "PostgresImage": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "PostgresMemory": {
+      "Default": "256",
+      "Description": "MB of RAM to reserve",
+      "Type": "Number"
+    },
+    "PostgresService": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "Release": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "Repository": {
+      "Default": "",
+      "Description": "Source code repository",
+      "Type": "String"
+    },
+    "Subnets": {
+      "Default": "",
+      "Description": "VPC subnets for this app",
+      "Type": "List\u003cAWS::EC2::Subnet::Id\u003e"
+    },
+    "VPC": {
+      "Default": "",
+      "Description": "VPC for this app",
+      "Type": "AWS::EC2::VPC::Id"
+    },
+    "Version": {
+      "Default": "latest",
+      "Description": "Convox release version",
+      "Type": "String"
+    },
+    "WebCommand": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "WebDesiredCount": {
+      "Default": "1",
+      "Description": "The number of instantiations of the process to place and keep running on your cluster",
+      "Type": "Number"
+    },
+    "WebImage": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    },
+    "WebMemory": {
+      "Default": "256",
+      "Description": "MB of RAM to reserve",
+      "Type": "Number"
+    },
+    "WebPort3000Container": {
+      "Default": "3000",
+      "Description": "Exposed port from within container",
+      "Type": "String"
+    },
+    "WebService": {
+      "Default": "",
+      "Description": "",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "CustomTopic": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Join": [
+              "-",
+              [
+                "convox",
+                {
+                  "Ref": "AWS::Region"
+                }
+              ]
+            ]
+          },
+          "S3Key": {
+            "Fn::Join": [
+              "",
+              [
+                "release/",
+                {
+                  "Ref": "Version"
+                },
+                "/formation.zip"
+              ]
+            ]
+          }
+        },
+        "Handler": "lambda.external",
+        "MemorySize": "128",
+        "Role": {
+          "Fn::GetAtt": [
+            "CustomTopicRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs",
+        "Timeout": "30"
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "CustomTopicRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Effect": "Allow",
+                  "Resource": "*"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "Administrator"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "Kinesis": {
+      "Properties": {
+        "ShardCount": 1
+      },
+      "Type": "AWS::Kinesis::Stream"
+    },
+    "LogsAccess": {
+      "Properties": {
+        "Serial": "1",
+        "Status": "Active",
+        "UserName": {
+          "Ref": "LogsUser"
+        }
+      },
+      "Type": "AWS::IAM::AccessKey"
+    },
+    "LogsUser": {
+      "Properties": {
+        "Path": "/convox/",
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "kinesis:PutRecords"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:kinesis:*:*:stream/",
+                          {
+                            "Ref": "AWS::StackName"
+                          },
+                          "-*"
+                        ]
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "LogsRole"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::User"
+    },
+    "PostgresECSService": {
+      "DependsOn": "CustomTopic",
+      "Properties": {
+        "Cluster": {
+          "Ref": "Cluster"
+        },
+        "DesiredCount": {
+          "Ref": "PostgresDesiredCount"
+        },
+        "LoadBalancers": [],
+        "Name": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName"
+              },
+              "postgres"
+            ]
+          ]
+        },
+        "Role": {
+          "Ref": "ServiceRole"
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomTopic",
+            "Arn"
+          ]
+        },
+        "TaskDefinition": {
+          "Ref": "PostgresECSTaskDefinition"
+        }
+      },
+      "Type": "Custom::ECSService",
+      "Version": "1.0"
+    },
+    "PostgresECSTaskDefinition": {
+      "DependsOn": [
+        "CustomTopic",
+        "ServiceRole"
+      ],
+      "Properties": {
+        "Environment": {
+          "Ref": "Environment"
+        },
+        "Key": {
+          "Ref": "Key"
+        },
+        "Name": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName"
+              },
+              "postgres"
+            ]
+          ]
+        },
+        "Release": {
+          "Ref": "Release"
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomTopic",
+            "Arn"
+          ]
+        },
+        "Tasks": [
+          {
+            "Fn::If": [
+              "BlankPostgresService",
+              {
+                "CPU": {
+                  "Ref": "Cpu"
+                },
+                "Command": {
+                  "Ref": "PostgresCommand"
+                },
+                "Environment": {
+                  "KINESIS": {
+                    "Ref": "Kinesis"
+                  },
+                  "POSTGRES_PASSWORD": "password",
+                  "POSTGRES_USERNAME": "postgres",
+                  "PROCESS": "postgres"
+                },
+                "Image": {
+                  "Ref": "PostgresImage"
+                },
+                "Links": [],
+                "Memory": {
+                  "Ref": "PostgresMemory"
+                },
+                "Name": "postgres",
+                "PortMappings": [],
+                "Services": [],
+                "Volumes": []
+              },
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ]
+          }
+        ]
+      },
+      "Type": "Custom::ECSTaskDefinition",
+      "Version": "1.0"
+    },
+    "ServiceRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "ecs.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "elasticloadbalancing:Describe*",
+                    "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                    "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+                    "ec2:Describe*",
+                    "ec2:AuthorizeSecurityGroupIngress"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    "*"
+                  ]
+                }
+              ]
+            },
+            "PolicyName": "ServiceRole"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "Settings": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AccessControl": "Private",
+        "Tags": [
+          {
+            "Key": "system",
+            "Value": "convox"
+          },
+          {
+            "Key": "app",
+            "Value": {
+              "Ref": "AWS::StackName"
+            }
+          }
+        ]
+      },
+      "Type": "AWS::S3::Bucket"
+    },
+    "WebECSService": {
+      "DependsOn": "CustomTopic",
+      "Properties": {
+        "Cluster": {
+          "Ref": "Cluster"
+        },
+        "DesiredCount": {
+          "Ref": "WebDesiredCount"
+        },
+        "LoadBalancers": [],
+        "Name": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName"
+              },
+              "web"
+            ]
+          ]
+        },
+        "Role": {
+          "Ref": "ServiceRole"
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomTopic",
+            "Arn"
+          ]
+        },
+        "TaskDefinition": {
+          "Ref": "WebECSTaskDefinition"
+        }
+      },
+      "Type": "Custom::ECSService",
+      "Version": "1.0"
+    },
+    "WebECSTaskDefinition": {
+      "DependsOn": [
+        "CustomTopic",
+        "ServiceRole"
+      ],
+      "Properties": {
+        "Environment": {
+          "Ref": "Environment"
+        },
+        "Key": {
+          "Ref": "Key"
+        },
+        "Name": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName"
+              },
+              "web"
+            ]
+          ]
+        },
+        "Release": {
+          "Ref": "Release"
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomTopic",
+            "Arn"
+          ]
+        },
+        "Tasks": [
+          {
+            "Fn::If": [
+              "BlankWebService",
+              {
+                "CPU": {
+                  "Ref": "Cpu"
+                },
+                "Command": {
+                  "Ref": "WebCommand"
+                },
+                "Environment": {
+                  "KINESIS": {
+                    "Ref": "Kinesis"
+                  },
+                  "PROCESS": "web"
+                },
+                "Image": {
+                  "Ref": "WebImage"
+                },
+                "Links": [
+                  {
+                    "Fn::If": [
+                      "BlankPostgresService",
+                      {
+                        "Ref": "AWS::NoValue"
+                      },
+                      {
+                        "Ref": "AWS::NoValue"
+                      }
+                    ]
+                  }
+                ],
+                "Memory": {
+                  "Ref": "WebMemory"
+                },
+                "Name": "web",
+                "PortMappings": [
+                  {
+                    "Fn::Join": [
+                      ":",
+                      [
+                        0,
+                        {
+                          "Ref": "WebPort3000Container"
+                        }
+                      ]
+                    ]
+                  }
+                ],
+                "Services": [
+                  {
+                    "Fn::If": [
+                      "BlankPostgresService",
+                      {
+                        "Ref": "AWS::NoValue"
+                      },
+                      {
+                        "Fn::Join": [
+                          ":",
+                          [
+                            {
+                              "Ref": "PostgresService"
+                            },
+                            "postgres"
+                          ]
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "Volumes": []
+              },
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ]
+          }
+        ]
+      },
+      "Type": "Custom::ECSTaskDefinition",
+      "Version": "1.0"
+    }
+  }
+}

--- a/fixtures/web_postgis_internal.json
+++ b/fixtures/web_postgis_internal.json
@@ -1,4 +1,3 @@
-len:  1
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Conditions": {

--- a/fixtures/web_postgis_internal.yml
+++ b/fixtures/web_postgis_internal.yml
@@ -1,0 +1,16 @@
+web:
+  build: .
+  environment:
+   - AWS_ACCESS_KEY
+   - AWS_SECRET_ACCESS_KEY
+  links:
+    - postgres
+  ports:
+    - 3000
+  volumes:
+    - .:/app
+postgres:
+  image: mdillon/postgis
+  environment:
+   - POSTGRES_USERNAME=postgres
+   - POSTGRES_PASSWORD=password

--- a/main.go
+++ b/main.go
@@ -241,8 +241,6 @@ func templateHelpers() template.FuncMap {
 			for _, port := range entry.Ports {
 				parts := strings.Split(port, ":")
 
-				fmt.Println("len: ", len(parts))
-
 				if len(parts) == 1 {
 					mappings = append(mappings, fmt.Sprintf(`{ "Fn::Join": [ ":", [ 0, { "Ref": "%sPort%sContainer" } ] ] }`, upperName(ps), parts[0]))
 				} else {

--- a/main_test.go
+++ b/main_test.go
@@ -41,8 +41,8 @@ func testTemplateOutput(name string, t *testing.T) {
 	_assert(t, cases)
 }
 
-func TestStagingWebInternalOnly(t *testing.T) {
-	testTemplateOutput("web_internal_only", t)
+func TestStagingWebPostgisInternal(t *testing.T) {
+	testTemplateOutput("web_postgis_internal", t)
 }
 
 func TestStagingWebPostgis(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -28,9 +28,9 @@ func TestManifestEntryNames(t *testing.T) {
 	_assert(t, cases)
 }
 
-func TestStagingWebPostgis(t *testing.T) {
-	manifest := readManifest(t, "fixtures", "web_postgis.yml")
-	template := readFile(t, "fixtures", "web_postgis.json")
+func testTemplateOutput(name string, t *testing.T) {
+	manifest := readManifest(t, "fixtures", fmt.Sprintf("%s.yml", name))
+	template := readFile(t, "fixtures", fmt.Sprintf("%s.json", name))
 
 	data, _ := buildTemplate("staging", "formation", func() string { return "12345" }, manifest)
 
@@ -41,17 +41,16 @@ func TestStagingWebPostgis(t *testing.T) {
 	_assert(t, cases)
 }
 
+func TestStagingWebInternalOnly(t *testing.T) {
+	testTemplateOutput("web_internal_only", t)
+}
+
+func TestStagingWebPostgis(t *testing.T) {
+	testTemplateOutput("web_postgis", t)
+}
+
 func TestStagingWorker(t *testing.T) {
-	manifest := readManifest(t, "fixtures", "worker.yml")
-	template := readFile(t, "fixtures", "worker.json")
-
-	data, _ := buildTemplate("staging", "formation", func() string { return "12345" }, manifest)
-
-	cases := Cases{
-		{strings.TrimSpace(data), strings.TrimSpace(string(template))},
-	}
-
-	_assert(t, cases)
+	testTemplateOutput("worker", t)
 }
 
 func readFile(t *testing.T, dir string, name string) []byte {

--- a/template/staging.tmpl
+++ b/template/staging.tmpl
@@ -233,15 +233,20 @@
   {{ range $ps, $entry := . }}
     {{ range $i, $port := $entry.Ports }}
       {{ $parts := (split $port ":") }}
+      "{{ upper $ps }}Port{{ index $parts 0 }}Container": {
+        "Type": "String",
+        "Default": "{{ index $parts 1 }}",
+        "Description": "Exposed port from within container"
+      },
       "{{ upper $ps }}Port{{ index $parts 0 }}Balancer": {
         "Type" : "String",
         "Default" : "{{ index $parts 0 }}",
-        "Description" : ""
+        "Description" : "Externally bound port number"
       },
       "{{ upper $ps }}Port{{ index $parts 0 }}Host": {
         "Type" : "String",
         "Default" : "{{ index $entry.Randoms $i }}",
-        "Description" : ""
+        "Description" : "Container host mapped port"
       },
     {{ end }}
   {{ end }}

--- a/template/staging.tmpl
+++ b/template/staging.tmpl
@@ -232,6 +232,7 @@
 {{ define "balancer-params" }}
   {{ range $ps, $entry := . }}
     {{ range $i, $port := $entry.Ports }}
+      {{ if (contains $port ":") }}
       {{ $parts := (split $port ":") }}
       "{{ upper $ps }}Port{{ index $parts 0 }}Container": {
         "Type": "String",
@@ -248,12 +249,19 @@
         "Default" : "{{ index $entry.Randoms $i }}",
         "Description" : "Container host mapped port"
       },
+      {{ else }}
+      "{{ upper $ps }}Port{{ $port }}Container": {
+        "Type": "String",
+        "Default": "{{ $port }}",
+        "Description": "Exposed port from within container"
+      },
+      {{ end }}
     {{ end }}
   {{ end }}
 {{ end }}
 
 {{ define "balancer-outputs" }}
-  {{ if .HasPorts }}
+  {{ if .HasExternalPorts }}
     "BalancerHost": {
       "Value": { "Fn::GetAtt": [ "Balancer", "DNSName" ] }
     },
@@ -271,7 +279,7 @@
 {{ end }}
 
 {{ define "balancer-resources" }}
-  {{ if .HasPorts }}
+  {{ if .HasExternalPorts }}
     "BalancerSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {


### PR DESCRIPTION
This PR allows ports to be mapped from the container to the ECS host, without creating a load balancer. We only do this in cases where the port is a single number instead of a host:container pair. We allow ECS to create an ephemeral port assignment on the ECS host that is mapped to the specified port within the container.

As usual, let me know if you see anything you'd like me to adjust. Thanks!